### PR TITLE
Improve `<Select>`

### DIFF
--- a/example/src/components/examples/Inputs.js
+++ b/example/src/components/examples/Inputs.js
@@ -10,8 +10,11 @@ import {
 
 class Inputs extends React.Component {
   state = {
-    textInputWithValueValue: 'value'
+    textInputWithValueValue: 'value',
+    selectValue: '1'
   }
+
+  handleSelectChange = e => this.setState({selectValue: e.target.value})
 
   handleTextInputChange = e => {
     this.setState({textInputWithValueValue: e.value})
@@ -101,24 +104,25 @@ class Inputs extends React.Component {
 
   renderSelects = () => {
     const options = [
-      {value: 34, text: 'First val'},
-      {value: 34, text: 'Second val'}
+      {value: '1', text: 'Option 1'},
+      {value: '2', text: 'Option 2'},
+      {value: '3', text: 'Option 3', disabled: true}
     ]
 
-    return (
-      <>
-        <h3>Select:</h3>
+    return (<>
+      <h3>Select:</h3>
 
-        <Select
-          className='extra-class'
-          data-extra-attribute
-          id='select-normal'
-          label='Select Label'
-          options={options}
-          width={100}
-        />
-      </>
-    )
+      <Select
+        className='extra-class'
+        data-extra-attribute
+        id='select-normal'
+        label='Select Label'
+        onChange={this.handleSelectChange}
+        options={options}
+        value={this.state.selectValue}
+        width={100}
+      />
+    </>)
   }
 
   renderTextInputs = () => (

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -49,7 +49,15 @@ class Icon extends React.Component {
   }
 
   render = () => {
-    const {className, name, toggle, ...props} = this.props
+    const {
+      className,
+      name,
+      select,
+      size,
+      toggle,
+      variant,
+      ...props
+    } = this.props
 
     return (
       <svg

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -11,6 +11,7 @@ class Select extends React.Component {
   static defaultProps = {
     disabled: false,
     error: null,
+    value: null,
     width: 100
   }
 
@@ -22,7 +23,12 @@ class Select extends React.Component {
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     name: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.object),
+    options: PropTypes.arrayOf(PropTypes.shape({
+      disabled: PropTypes.bool,
+      text: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired
+    })).isRequired,
+    value: PropTypes.string,
     width: PropTypes.number
   }
 
@@ -56,6 +62,7 @@ class Select extends React.Component {
       label,
       name,
       options,
+      value,
       ...props
     } = this.props
 
@@ -70,20 +77,18 @@ class Select extends React.Component {
           id={id}
           name={name}
           ref={this.selectRef}
+          value={value}
           {...props}
         >
-          {options.map(
-            ({disabled = false, value, selected = false, text}, index) => (
-              <option
-                disabled={disabled}
-                value={value}
-                selected={selected}
-                key={index}
-              >
-                {text}
-              </option>
-            )
-          )}
+          {options.map(({disabled = false, value, text}, index) => (
+            <option
+              disabled={disabled}
+              value={value}
+              key={index}
+            >
+              {text}
+            </option>
+          ))}
         </select>
         <Icon name='chevron-down' select />
       </InputContainer>


### PR DESCRIPTION
# Changed:

- Set currently selected `<Select>` option using the `value` prop instead of
  `option.selected`. See [React docs](https://reactjs.org/docs/forms.html#the-select-tag)
- Improve `<Select>` prop types

# Fixed:

- Destructure more props in `<Icon>` to prevent unwanted attributes from making
  it to the DOM