### PR TITLE
Clean up accordion

### DIFF
--- a/example/src/components/examples/Accordions.js
+++ b/example/src/components/examples/Accordions.js
@@ -1,80 +1,63 @@
 import React from 'react'
-import { Accordion } from 'react-spark'
+import { Accordion, List, Type } from 'react-spark'
 
 class Accordions extends React.Component {
   item1 = 'acc-1';
   item2 = 'acc-2';
   item3 = 'acc-3';
-  item4 = 'acc-4';
 
   render = () => (
     <>
       <h2>Accordions</h2>
 
-      <Accordion padding className='extra-class' data-extra-attribute>
-        <Accordion.Item className='extra-class' data-extra-attribute>
-          <Accordion.Header
-            id='head1'
-            className='extra-class'
-            control={this.item1}
-            data-extra-attribute
-          >
-            <h3 className='sprk-c-Accordion__heading sprk-b-TypeDisplaySeven'>
-              Header
-            </h3>
+      <Accordion className='extra-class' data-extra-attribute>
+        <Accordion.Item>
+          <Accordion.Header control={this.item1}>
+            This is an accordion heading
           </Accordion.Header>
-          <Accordion.Content
-            className='extra-class'
-            data-extra-attribute
-            id={this.item1}
-          >
-            Content
+          <Accordion.Content id={this.item1}>
+            <Type.BodyTwo>
+              This is an example of multiple HTML elements used for the
+              content in an accordion item.
+            </Type.BodyTwo>
+            <List variant='indented'>
+              <li>List Item One</li>
+              <li>List Item Two</li>
+              <li>List Item Three</li>
+            </List>
           </Accordion.Content>
         </Accordion.Item>
-
-        <Accordion.Item>
+        <Accordion.Item className='extra-class' data-extra-attribute>
           <Accordion.Header
+            className='extra-class'
             control={this.item2}
-            id='head2'
             data-extra-attribute
           >
-            <h3 className='sprk-c-Accordion__heading sprk-b-TypeDisplaySeven'>
-              Header 2
-            </h3>
-          </Accordion.Header>
-          <Accordion.Content id={this.item2}>Content 2</Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
-      <br />
-      <br />
-      <Accordion padding className='extra-class' data-extra-attribute>
-        <Accordion.Item className='extra-class' data-extra-attribute>
-          <Accordion.Header
-            id='head3'
-            className='extra-class'
-            control={this.item3}
-            data-extra-attribute
-          >
-            <h3 className='sprk-c-Accordion__heading sprk-b-TypeDisplaySeven'>
-              Header
-            </h3>
+            This is an accordion heading
           </Accordion.Header>
           <Accordion.Content
             className='extra-class'
             data-extra-attribute
-            id={this.item3}
+            id={this.item2}
           >
-            Content
+            <Type.BodyTwo>
+              This is an example of accordion content. This is an example of
+              accordion content. This is an example of accordion content. This
+              is an example of accordion content.
+            </Type.BodyTwo>
           </Accordion.Content>
         </Accordion.Item>
-
         <Accordion.Item>
-          <Accordion.Header control={this.item4} id='head4'>
-            <h3 className='sprk-c-Accordion__heading sprk-b-TypeDisplaySeven'>
-              Header 2
-            </h3>
+          <Accordion.Header control={this.item3}>
+            This is an accordion heading
           </Accordion.Header>
-          <Accordion.Content id={this.item4}>Content 2</Accordion.Content>
+          <Accordion.Content id={this.item3}>
+            <Type.BodyTwo>
+              This is an example of accordion content. This is an example of
+              accordion content. This is an example of accordion content. This
+              is an example of accordion content.
+            </Type.BodyTwo>
+          </Accordion.Content>
         </Accordion.Item>
       </Accordion>
     </>

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -1,42 +1,44 @@
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import React from 'react';
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
 
-import { sparkComponentClassName, sparkObjectClassName } from '../../util';
+import { sparkComponentClassName, sparkObjectClassName } from '../../util'
 
-import Item from './Item';
-import Header from './Header';
-import Content from './Content';
+import Content from './Content'
+import Header from './Header'
+import Item from './Item'
 
 class Accordion extends React.Component {
   static defaultProps = {
-    padding: false
-  };
+    className: null
+  }
 
   static propTypes = {
-    padding: PropTypes.bool
-  };
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  }
 
-  get className() {
-    const { className, padding } = this.props
-    const baseClass = sparkObjectClassName('VerticalList')
-    const paddingClass = sparkComponentClassName('Accordion')
+  get className () {
+    const { className } = this.props
 
-    return classNames(baseClass, {
-      [paddingClass]: padding,
-      [className]: className
-    })
+    return classNames(
+      [
+        sparkComponentClassName('Accordion'),
+        sparkObjectClassName('VerticalList')
+      ],
+      { [className]: className }
+    )
   }
 
   render = () => {
-    const { children, className, padding, ...props } = this.props
+    const { children, className, ...props } = this.props
 
     return (
       <ul className={this.className} {...props}>
         {children}
       </ul>
     )
-  };
+  }
 }
 
 Accordion.Item = Item

--- a/src/components/Accordion/Content.js
+++ b/src/components/Accordion/Content.js
@@ -5,13 +5,19 @@ import React from 'react'
 import { sparkComponentClassName, sparkObjectClassName } from '../../util'
 
 class AccordionContent extends React.Component {
-  static defaultProps = {};
+  static defaultProps = {
+    children: null,
+    className: null
+  }
 
   static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    // Must match the `control` prop of <Accordion.Header>
     id: PropTypes.string.isRequired
-  };
+  }
 
-  get className() {
+  get className () {
     const { className } = this.props
 
     return classNames(
@@ -28,11 +34,13 @@ class AccordionContent extends React.Component {
     return (
       <div id={id} data-sprk-toggle='content'>
         <div className={this.className} {...props}>
-          {children}
+          <div className={sparkComponentClassName('Stack', 'item')}>
+            {children}
+          </div>
         </div>
       </div>
     )
-  };
+  }
 }
 
 export default AccordionContent

--- a/src/components/Accordion/Header.js
+++ b/src/components/Accordion/Header.js
@@ -1,36 +1,40 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+
 import { sparkComponentClassName } from '../../util'
 import Icon from '../Icon'
-import Stack from '../Stack'
+import Type from '../Type'
 
 class AccordionHeader extends React.Component {
   static defaultProps = {
-    analytics: '',
-    children: null
-  };
+    children: null,
+    className: null,
+    element: 'h3'
+  }
 
   static propTypes = {
-    analytics: PropTypes.string,
     children: PropTypes.node,
+    className: PropTypes.string,
     control: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired
-  };
+    element: PropTypes.string
+  }
 
-  get className() {
+  get className () {
     const { className } = this.props
-    const baseClass = sparkComponentClassName('Accordion', 'summary')
-    return classNames(baseClass, { [className]: className })
+
+    return classNames(
+      sparkComponentClassName('Accordion', 'summary'),
+      { [className]: className }
+    )
   }
 
   render = () => {
     const {
-      analytics,
-      id,
       children,
       className,
       control,
+      element,
       ...props
     } = this.props
 
@@ -38,14 +42,17 @@ class AccordionHeader extends React.Component {
       <a
         aria-controls={control}
         className={this.className}
-        data-analytics={analytics}
-        data-id={id}
         data-sprk-toggle='trigger'
         data-sprk-toggle-type='accordion'
         href='#'
         {...props}
       >
-        {children}
+        <Type.DisplaySeven
+          className={sparkComponentClassName('Accordion', 'heading')}
+          element={element}
+        >
+          {children}
+        </Type.DisplaySeven>
         <Icon
           name='chevron-up-circle-two-color'
           size='l'
@@ -54,7 +61,7 @@ class AccordionHeader extends React.Component {
         />
       </a>
     )
-  };
+  }
 }
 
 export default AccordionHeader

--- a/src/components/Accordion/Item.js
+++ b/src/components/Accordion/Item.js
@@ -1,10 +1,25 @@
+import { bindToggleUIEvents } from '@sparkdesignsystem/spark-core/components/toggle'
 import classNames from 'classnames'
+import PropTypes from 'prop-types'
 import React from 'react'
+
 import { sparkComponentClassName } from '../../util'
-import { bindToggleUIEvents } from '@sparkdesignsystem/spark-core'
 
 class AccordionItem extends React.Component {
-  get className() {
+  static defaultProps = {
+    className: null,
+    open: false
+  }
+
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    open: PropTypes.bool
+  }
+
+  ref = React.createRef()
+
+  get className () {
     const { className, open } = this.props
     const baseClass = sparkComponentClassName('Accordion', 'item')
     const openClass = sparkComponentClassName('Accordion', 'item--open')
@@ -15,25 +30,23 @@ class AccordionItem extends React.Component {
     })
   }
 
-  ref = React.createRef();
-
-  componentDidMount() {
+  componentDidMount () {
     bindToggleUIEvents(this.ref.current)
   }
+
   render = () => {
     const { children, className, ...props } = this.props
 
     return (
       <li
         className={this.className}
-        data-sprk-toggle='container'
         ref={this.ref}
         {...props}
       >
         {children}
       </li>
     )
-  };
+  }
 }
 
 export default AccordionItem

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -49,7 +49,15 @@ class Icon extends React.Component {
   }
 
   render = () => {
-    const { className, name, toggle, select, ...props } = this.props
+    const {
+      className,
+      name,
+      select,
+      toggle,
+      variant,
+      ...props
+    } = this.props
+
     const toggleProps = {}
     if (toggle) {
       toggleProps['data-sprk-toggle'] = 'icon'


### PR DESCRIPTION
Added:

- `<Accordion>`
  - Missing `className` prop type
- `<Accordion.Content>`
  - Missing `className` prop type
- `<Accordion.Header>`
  - Missing `.Accordion__heading` element
  - `element` prop so you can specify a heading tag for the new
    `.Accordion__heading`. Defaults to `<h3>`.
- `<Accordion.Item>`
  - Missing prop types
- `<Icon>`
  - `variant` to destructured `this.props` because it was making it to the DOM

Changed:

- Make accordions example screen match Spark's website
- `<Accordion.Content>`
  - Wrap content in `.Stack__item` because `.Accordion__content` is also a
    `.Stack`
- Code style

Removed:

- `<Accordion>`
  - `padding` prop because it didn't make sense
- `<Accordion.Header>`
  - `analytics` prop because it's not related to Spark
  - `data-analytics` and `data-id` attributes because they're not related to
    Spark
- `<Accordion.Item>`
  - `data-sprk-toggle` attribute because we don't use it