### PR TITLE
Dsteele/feat/servicing dashboard refactor

### DIFF
--- a/src/components/Dictionary/Dictionary.js
+++ b/src/components/Dictionary/Dictionary.js
@@ -34,7 +34,7 @@ class Dictionary extends React.Component {
   }
 
   render = () => {
-    const { children, className, ...props } = this.props
+    const { children, className,bold, ...props } = this.props
 
     return (
       <div className={this.dictionaryClassName} {...props}>

--- a/src/components/Dictionary/Item.js
+++ b/src/components/Dictionary/Item.js
@@ -35,11 +35,11 @@ class Item extends React.Component {
   }
 
   render = () => {
-    const {className, itemKey, itemValue, ...props} = this.props
+    const {className, itemKey, itemValue,bold, ...props} = this.props
 
     return (
       <div className={this.className} {...props}>
-        <dt className={this.keyClassName}>{itemKey}</dt>
+        <dt className={this.keyClassName}><b>{itemKey}</b></dt>
         <dd className={this.valueClassName}>{itemValue}</dd>
       </div>
     )

--- a/src/components/InputContainer/InputContainer.js
+++ b/src/components/InputContainer/InputContainer.js
@@ -24,6 +24,9 @@ class InputContainer extends React.Component {
   get className() {
     const { className } = this.props
 
+    if(className && className.includes("InputContainer")) {
+      return className;
+    }
     return classNames(sparkBaseClassName('InputContainer'), {
       [className]: className
     })

--- a/src/components/MonetaryInput/MonetaryInput.js
+++ b/src/components/MonetaryInput/MonetaryInput.js
@@ -17,6 +17,7 @@ class MonetaryInput extends React.Component {
     onBlur: () => {},
     onChange: () => {},
     pattern: '(^\\$?(\\d+|\\d{1,3}(,\\d{3})*)(\\.\\d+)?$)|^$',
+    parentContainerClassName: null,
     type: 'tel',
     value: '',
     width: 100,
@@ -37,7 +38,8 @@ class MonetaryInput extends React.Component {
     value: PropTypes.string,
     helper: PropTypes.node,
     width: PropTypes.number,
-    noCents: PropTypes.bool
+    noCents: PropTypes.bool,
+    parentContainerClassName: PropTypes.string
   };
 
   get className() {
@@ -141,6 +143,7 @@ class MonetaryInput extends React.Component {
       width,
       helper,
       noCents,
+      parentContainerClassName,
       ...props
     } = this.props
 
@@ -150,6 +153,7 @@ class MonetaryInput extends React.Component {
         helper={helper}
         id={id}
         inputRef={this.inputRef}
+        className={parentContainerClassName}
         data-sprk-input='monetary'
       >
         <div className={this.iconContainerClassName} ref={this.inputRef}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { SprkDatePickerInput } from '@sparkdesignsystem/spark-react';
 export { default as Accordion } from './components/Accordion'
 export { default as Alert } from './components/Alert'
 export { default as Box } from './components/Box'


### PR DESCRIPTION
Part of servicing dashboard refresh.

Includes:
* `Dictionary` has an optional bold prop now
* `InputContainer` and `MonetaryInput` have optional `parentContainerClassName` to override that class
* Added Sparks `DatePicker` to the exports 