### PR TITLE
exposed spinner bool for buttons in modal

### DIFF
--- a/src/components/InputContainer/InputContainer.js
+++ b/src/components/InputContainer/InputContainer.js
@@ -47,7 +47,7 @@ class InputContainer extends React.Component {
 
       return (
         <div className={sparkClassName('utility', 'JavaScript')}>
-            <div className={this.className} ref={inputRef} {...props}>
+            <div className={className || this.className} ref={inputRef} {...props}>
                 {label && (
                   <label htmlFor={id} className={sparkClassName('base', 'Label')}>
                           {label}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -36,7 +36,8 @@ class Modal extends Component {
     title: PropTypes.string.isRequired,
     type: PropTypes.oneOf(
       Object.keys(MODAL_VARIANTS).map(itm => MODAL_VARIANTS[itm])
-    ).isRequired
+    ).isRequired,
+    spinner: PropTypes.bool
   };
 
   mainRef = React.createRef();
@@ -120,6 +121,7 @@ class Modal extends Component {
       show,
       title,
       type,
+      spinner,
       ...props
     } = this.props
 
@@ -162,6 +164,7 @@ class Modal extends Component {
                 modalId={id}
                 onCancel={onCancel}
                 onConfirm={onConfirm}
+                spinner={spinner}
               />
             )}
           </Stack>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -37,7 +37,8 @@ class Modal extends Component {
     type: PropTypes.oneOf(
       Object.keys(MODAL_VARIANTS).map(itm => MODAL_VARIANTS[itm])
     ).isRequired,
-    spinner: PropTypes.bool
+    spinner: PropTypes.bool,
+    itemSpacing: PropTypes.string
   };
 
   mainRef = React.createRef();
@@ -46,7 +47,7 @@ class Modal extends Component {
 
 
   escapeModal = (event) => {
-    if(event.keyCode === escapeKey && this.props.onClose && this.props.show) {
+    if (event.keyCode === escapeKey && this.props.onClose && this.props.show) {
       this.props.onClose();
     }
   }
@@ -122,6 +123,7 @@ class Modal extends Component {
       title,
       type,
       spinner,
+      itemSpacing,
       ...props
     } = this.props
 
@@ -145,7 +147,7 @@ class Modal extends Component {
           tabIndex='-1'
           {...props}
         >
-          <Stack itemSpacing={'large'}>
+          <Stack itemSpacing={itemSpacing ? itemSpacing : 'large'}>
             <ModalHeader
               hasCloseButton={
                 type !== MODAL_VARIANTS.WAIT ? hasCloseButton : false

--- a/src/components/Modal/ModalFooter.js
+++ b/src/components/Modal/ModalFooter.js
@@ -14,7 +14,8 @@ class ModalFooter extends React.Component {
     onCancel: PropTypes.func,
     confirmText: PropTypes.string,
     cancelText: PropTypes.string,
-    modalId: PropTypes.string
+    modalId: PropTypes.string,
+    spinner: PropTypes.bool
   }
 
   get className() {
@@ -24,13 +25,14 @@ class ModalFooter extends React.Component {
   }
 
   render = () => {
-    const { confirmText, cancelText, onConfirm, onCancel, modalId } = this.props
+    const { confirmText, cancelText, onConfirm, onCancel, modalId, spinner } = this.props
     return (
       <footer className={this.className}>
         <Button
           id={`${modalId}-button-confirm`}
           name='confirm'
           onClick={onConfirm}
+          spinner={spinner}
         >
           {confirmText}
         </Button>
@@ -42,6 +44,7 @@ class ModalFooter extends React.Component {
           data-sprk-modal-cancel={modalId}
           aria-label='Close Modal'
           onClick={onCancel}
+          disabled={spinner}
         >
           {cancelText}
         </Button>

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -18,7 +18,8 @@ class TextArea extends React.Component {
     error: PropTypes.string,
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    width: PropTypes.number
+    width: PropTypes.number,
+    parentContainerClassName: PropTypes.string
   };
 
   get className() {
@@ -35,7 +36,7 @@ class TextArea extends React.Component {
   }
 
   render = () => {
-    const { className, disabled, error, id, label, ...props } = this.props
+    const { className, disabled, error, id, label, parentContainerClassName, ...props } = this.props
 
     return (
       <InputContainer
@@ -43,6 +44,7 @@ class TextArea extends React.Component {
         id={id}
         label={label}
         positionLabelUpper={true}
+        className={parentContainerClassName}
         inputRef={this.inputRef}
       >
         <textarea


### PR DESCRIPTION
Updated `Modal` class to expose the `Button`'s spinner class.

This allows an easy way to show a client the modal is loading currently.

`Modal` prop: `spinner?: boolean`

`ModalFooter` prop: `spinner?: boolean`