### PR TITLE
added some optional props to modal and radio buttons

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -38,7 +38,8 @@ class Modal extends Component {
       Object.keys(MODAL_VARIANTS).map(itm => MODAL_VARIANTS[itm])
     ).isRequired,
     spinner: PropTypes.bool,
-    itemSpacing: PropTypes.string
+    itemSpacing: PropTypes.string,
+    showFooter: PropTypes.bool
   };
 
   mainRef = React.createRef();
@@ -124,6 +125,7 @@ class Modal extends Component {
       type,
       spinner,
       itemSpacing,
+      showFooter,
       ...props
     } = this.props
 
@@ -167,6 +169,7 @@ class Modal extends Component {
                 onCancel={onCancel}
                 onConfirm={onConfirm}
                 spinner={spinner}
+                show={showFooter}
               />
             )}
           </Stack>

--- a/src/components/Modal/ModalFooter.js
+++ b/src/components/Modal/ModalFooter.js
@@ -6,7 +6,8 @@ import Button from '../Button'
 class ModalFooter extends React.Component {
   static defaultProps = {
     confirmText: 'Confirm',
-    cancelText: 'Cancel'
+    cancelText: 'Cancel',
+    show: true
   };
 
   static propTypes = {
@@ -15,7 +16,8 @@ class ModalFooter extends React.Component {
     confirmText: PropTypes.string,
     cancelText: PropTypes.string,
     modalId: PropTypes.string,
-    spinner: PropTypes.bool
+    spinner: PropTypes.bool,
+    show: PropTypes.bool
   }
 
   get className() {
@@ -25,29 +27,31 @@ class ModalFooter extends React.Component {
   }
 
   render = () => {
-    const { confirmText, cancelText, onConfirm, onCancel, modalId, spinner } = this.props
+    const { confirmText, cancelText, onConfirm, onCancel, modalId, spinner, show } = this.props
     return (
       <footer className={this.className}>
-        <Button
-          id={`${modalId}-button-confirm`}
-          name='confirm'
-          onClick={onConfirm}
-          spinner={spinner}
-        >
-          {confirmText}
-        </Button>
+        {show && <div>
+          <Button
+            id={`${modalId}-button-confirm`}
+            name='confirm'
+            onClick={onConfirm}
+            spinner={spinner}
+          >
+            {confirmText}
+          </Button>
 
-        <Button
-          id={`${modalId}-button-cancel`}
-          name='cancel'
-          className='sprk-c-Button sprk-c-Button--tertiary'
-          data-sprk-modal-cancel={modalId}
-          aria-label='Close Modal'
-          onClick={onCancel}
-          disabled={spinner}
-        >
-          {cancelText}
-        </Button>
+          <Button
+            id={`${modalId}-button-cancel`}
+            name='cancel'
+            className='sprk-c-Button sprk-c-Button--tertiary'
+            data-sprk-modal-cancel={modalId}
+            aria-label='Close Modal'
+            onClick={onCancel}
+            disabled={spinner}
+          >
+            {cancelText}
+          </Button>
+        </div>}
       </footer>
     )
   };

--- a/src/components/RadioGroup/RadioGroup.js
+++ b/src/components/RadioGroup/RadioGroup.js
@@ -32,7 +32,8 @@ class RadioGroup extends React.Component {
     error: PropTypes.string,
     id: PropTypes.string.isRequired,
     label: PropTypes.string,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    parentContainerClassName: PropTypes.string
   };
 
   get labelClassName() {
@@ -52,11 +53,12 @@ class RadioGroup extends React.Component {
       onChange,
       radios,
       value,
+      parentContainerClassName,
       ...props
     } = this.props
 
     return (
-      <InputContainer id={id} {...props}>
+      <InputContainer id={id} className={parentContainerClassName} {...props}>
         <Fieldset>
           <Legend>
             <Label>{label}</Label>


### PR DESCRIPTION
Added optional props for `Modal` and `RadioGroup`.

Modal: `showFooter` - added this to eliminate the ability to submit or cancel at points in time (mainly intended for state machine behavior).

RadioGroup: `parentContainerClassName` - added this to allow for the resizing of the parent `InputContainer` since this causes issues with forms not resizing properly.