### PR TITLE
Modal Updates

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -16,7 +16,8 @@ const escapeKey = 27;
 
 class Modal extends Component {
   static defaultProps = {
-    hasCloseButton: true
+    hasCloseButton: true,
+    disableConfirm: false
   };
   static propTypes = {
     ariaDescribedby: PropTypes.string,
@@ -39,7 +40,8 @@ class Modal extends Component {
     ).isRequired,
     spinner: PropTypes.bool,
     itemSpacing: PropTypes.string,
-    showFooter: PropTypes.bool
+    showFooter: PropTypes.bool,
+    disableConfirm: PropTypes.bool
   };
 
   mainRef = React.createRef();
@@ -126,6 +128,7 @@ class Modal extends Component {
       spinner,
       itemSpacing,
       showFooter,
+      disableConfirm,
       ...props
     } = this.props
 
@@ -170,6 +173,7 @@ class Modal extends Component {
                 onConfirm={onConfirm}
                 spinner={spinner}
                 show={showFooter}
+                disableConfirm={disableConfirm}
               />
             )}
           </Stack>

--- a/src/components/Modal/ModalFooter.js
+++ b/src/components/Modal/ModalFooter.js
@@ -7,7 +7,8 @@ class ModalFooter extends React.Component {
   static defaultProps = {
     confirmText: 'Confirm',
     cancelText: 'Cancel',
-    show: true
+    show: true,
+    disableConfirm: false
   };
 
   static propTypes = {
@@ -17,7 +18,8 @@ class ModalFooter extends React.Component {
     cancelText: PropTypes.string,
     modalId: PropTypes.string,
     spinner: PropTypes.bool,
-    show: PropTypes.bool
+    show: PropTypes.bool,
+    disableConfirm: PropTypes.bool
   }
 
   get className() {
@@ -27,7 +29,7 @@ class ModalFooter extends React.Component {
   }
 
   render = () => {
-    const { confirmText, cancelText, onConfirm, onCancel, modalId, spinner, show } = this.props
+    const { confirmText, cancelText, onConfirm, onCancel, modalId, spinner, show, disableConfirm } = this.props
     return (
       <footer className={this.className}>
         {show && <div>
@@ -36,6 +38,7 @@ class ModalFooter extends React.Component {
             name='confirm'
             onClick={onConfirm}
             spinner={spinner}
+            disabled={disableConfirm}
           >
             {confirmText}
           </Button>


### PR DESCRIPTION
Added the ability for modal's confirm button to be disabled until a certain condition is met.

This was added to allow for the functionality of adding an addition checkbox to modals that unless checked will not allow the client to continue forward in the modal.